### PR TITLE
Remove duplicate apns

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -9395,19 +9395,9 @@
       apn="ims"
       type="ims"
       protocol="IPV6"
-      mtu="1440"
-      bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17"
-  />
-
-  <apn carrier="T-Mobile US 260 IMS"
-      mcc="310"
-      mnc="260"
-      apn="ims"
-      type="ims"
-      protocol="IPV6"
       roaming_protocol="IPV6"
       mtu="1440"
-      bearer_bitmask="18"
+      bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18"
   />
 
   <apn carrier="T-Mobile MMS"
@@ -9418,18 +9408,7 @@
       type="mms"
       protocol="IPV4V6"
       roaming_protocol="IP"
-      bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17"
-  />
-
-  <apn carrier="T-Mobile MMS"
-       mcc="310"
-       mnc="260"
-       apn="TMUS"
-       mmsc="http://mms.msg.eng.t-mobile.com/mms/wapenc"
-       type="mms"
-       protocol="IPV6"
-       roaming_protocol="IPV6"
-       bearer_bitmask="18"
+      bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18"
   />
 
   <apn carrier="Project Fi - T"


### PR DESCRIPTION
If you go under Settings and check APNs, you'll see duplicate APNs for
T-Mobile US 260 and T-Mobile MMS. This fixes that.

Change-Id: Ibb5115a1cf25eed69fbc42b1d49b4d973996b8f7